### PR TITLE
Remove unused import

### DIFF
--- a/code/ops.py
+++ b/code/ops.py
@@ -10,7 +10,6 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import numpy as np
 import torch
 from scipy import linalg
-from scipy.misc import imread
 from torch.nn.functional import adaptive_avg_pool2d
 
 try:


### PR DESCRIPTION
This import can create an issue for people with a partial install of scipy and/or use imageio for imread/imwrite.